### PR TITLE
v0.1.9 version bump.

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -11,7 +11,7 @@ jobs:
 
   test:
     name: run tests and linters
-    uses: kubewarden/github-actions/.github/workflows/reusable-test-policy-go.yml@v3.0.0
+    uses: kubewarden/github-actions/.github/workflows/reusable-test-policy-go.yml@v3.0.4
 
   release:
     needs: test
@@ -23,6 +23,6 @@ jobs:
       # Required by cosign keyless signing
       id-token: write
 
-    uses: kubewarden/github-actions/.github/workflows/reusable-release-policy-go.yml@v3.0.0
+    uses: kubewarden/github-actions/.github/workflows/reusable-release-policy-go.yml@v3.0.4
     with:
       oci-target: ghcr.io/${{ github.repository_owner }}/policies/sysctl-psp

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -3,4 +3,4 @@ name: Continuous integration
 jobs:
   test:
     name: run tests and linters
-    uses: kubewarden/github-actions/.github/workflows/reusable-test-policy-go.yml@v3.0.0
+    uses: kubewarden/github-actions/.github/workflows/reusable-test-policy-go.yml@v3.0.4

--- a/artifacthub-pkg.yml
+++ b/artifacthub-pkg.yml
@@ -4,29 +4,29 @@
 #
 # This config can be saved to its default location with:
 #   kwctl scaffold artifacthub > artifacthub-pkg.yml 
-version: 0.1.8
+version: 0.1.9
 name: sysctl-psp
 displayName: Sysctl PSP
-createdAt: 2023-03-17T18:07:32.285118303Z
+createdAt: 2023-03-21T17:51:52.223492612Z
 description: A Pod Security Policy that controls usage of sysctls in pods
 license: Apache-2.0
 homeURL: https://github.com/kubewarden/sysctl-psp-policy
 containersImages:
 - name: policy
-  image: ghcr.io/kubewarden/policies/sysctl-psp:v0.1.8
+  image: ghcr.io/kubewarden/policies/sysctl-psp:v0.1.9
 keywords:
 - sysctl
 - psp
 - pod
 links:
 - name: policy
-  url: https://github.com/kubewarden/sysctl-psp-policy/releases/download/v0.1.8/policy.wasm
+  url: https://github.com/kubewarden/sysctl-psp-policy/releases/download/v0.1.9/policy.wasm
 - name: source
   url: https://github.com/kubewarden/sysctl-psp-policy
 install: |
   The policy can be obtained using [`kwctl`](https://github.com/kubewarden/kwctl):
   ```console
-  kwctl pull ghcr.io/kubewarden/policies/sysctl-psp:v0.1.8
+  kwctl pull ghcr.io/kubewarden/policies/sysctl-psp:v0.1.9
   ```
 maintainers:
 - name: Kubewarden developers


### PR DESCRIPTION
## Description

Bumps the version to v0.1.9 to include the recent changes how the Artifacthub file is generated.
