### PR TITLE
Bump v0.1.11 policy version.

### DIFF
--- a/artifacthub-pkg.yml
+++ b/artifacthub-pkg.yml
@@ -4,29 +4,29 @@
 #
 # This config can be saved to its default location with:
 #   kwctl scaffold artifacthub > artifacthub-pkg.yml 
-version: 0.1.10
+version: 0.1.11
 name: sysctl-psp
 displayName: Sysctl PSP
-createdAt: 2023-03-24T16:46:47.74692413Z
+createdAt: 2023-07-10T16:14:15.921200892Z
 description: A Pod Security Policy that controls usage of sysctls in pods
 license: Apache-2.0
 homeURL: https://github.com/kubewarden/sysctl-psp-policy
 containersImages:
 - name: policy
-  image: ghcr.io/kubewarden/policies/sysctl-psp:v0.1.10
+  image: ghcr.io/kubewarden/policies/sysctl-psp:v0.1.11
 keywords:
 - sysctl
 - psp
 - pod
 links:
 - name: policy
-  url: https://github.com/kubewarden/sysctl-psp-policy/releases/download/v0.1.10/policy.wasm
+  url: https://github.com/kubewarden/sysctl-psp-policy/releases/download/v0.1.11/policy.wasm
 - name: source
   url: https://github.com/kubewarden/sysctl-psp-policy
 install: |
   The policy can be obtained using [`kwctl`](https://github.com/kubewarden/kwctl):
   ```console
-  kwctl pull ghcr.io/kubewarden/policies/sysctl-psp:v0.1.10
+  kwctl pull ghcr.io/kubewarden/policies/sysctl-psp:v0.1.11
   ```
 maintainers:
 - name: Kubewarden developers


### PR DESCRIPTION
Bump v0.1.11 policy version.        

Updates files bumping the policy version to v0.1.11

Related to https://github.com/kubewarden/kubewarden-controller/issues/479
